### PR TITLE
Pass monitor name as optional description to $XPLUGRC.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS    = xplugd
 dist_man1_MANS  = xplugd.1
-xplugd_SOURCES  = xplugd.c xplugd.h exec.c input.c randr.c
+xplugd_SOURCES  = xplugd.c xplugd.h exec.c input.c randr.c edid-parse.c edid.h
 xplugd_CFLAGS   = -W -Wall -Wextra -std=c99
 xplugd_CFLAGS  += -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE -D_DEFAULT_SOURCE
 xplugd_CFLAGS  += $(X11_CFLAGS) $(Xi_CFLAGS) $(Xrandr_CFLAGS)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The keyboard or pointer is always the X slave keyboard or pointer, and
 the status encoding for `XIStatusEnabled` and `XIStatusDisabled` is
 forwarded to the script as connected and disconnected, respectively.
 
+If EDID data is available from a connected display, the monitor name is
+passed in as fourth argument ("Optional Description") to the script.
 
 `~/.xplugrc` example
 --------------------

--- a/edid-parse.c
+++ b/edid-parse.c
@@ -39,29 +39,23 @@ static int decode_header(const uchar *edid)
 static void decode_lf_string(const uchar *s, int n_chars, char *result)
 {
 	int i;
-	for (i = 0; i < n_chars; ++i)
-	{
-		if (s[i] == 0x0a)
-		{
+
+	for (i = 0; i < n_chars; ++i) {
+		if (s[i] == 0x0a) {
 			*result++ = '\0';
 			break;
-		}
-		else if (s[i] == 0x00)
-		{
+		} else if (s[i] == 0x00) {
 			/* Convert embedded 0's to spaces */
 			*result++ = ' ';
-		}
-		else
-		{
+		} else {
 			*result++ = s[i];
 		}
 	}
 }
 
-static void decode_display_descriptor(const uchar *desc, MonitorInfo *info)
+static void decode_display_descriptor(const uchar *desc, MonitorInfo * info)
 {
-	switch (desc[0x03])
-	{
+	switch (desc[0x03]) {
 	case 0xFC:
 		decode_lf_string(desc + 5, 13, info->dsc_product_name);
 		break;
@@ -94,16 +88,14 @@ static void decode_display_descriptor(const uchar *desc, MonitorInfo *info)
 	}
 }
 
-static int decode_descriptors(const uchar *edid, MonitorInfo *info)
+static int decode_descriptors(const uchar *edid, MonitorInfo * info)
 {
 	int i;
 
-	for (i = 0; i < 4; ++i)
-	{
+	for (i = 0; i < 4; ++i) {
 		int index = 0x36 + i * 18;
 
-		if (edid[index + 0] == 0x00 && edid[index + 1] == 0x00)
-		{
+		if (edid[index + 0] == 0x00 && edid[index + 1] == 0x00) {
 			decode_display_descriptor(edid + index, info);
 		}
 	}
@@ -111,7 +103,7 @@ static int decode_descriptors(const uchar *edid, MonitorInfo *info)
 	return TRUE;
 }
 
-static void decode_check_sum(const uchar *edid, MonitorInfo *info)
+static void decode_check_sum(const uchar *edid, MonitorInfo * info)
 {
 	int i;
 	uchar check = 0;

--- a/edid-parse.c
+++ b/edid-parse.c
@@ -26,14 +26,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define TRUE 1
-#define FALSE 0
-
-static int decode_header(const uchar *edid)
+static int is_edid_header(const uchar *edid)
 {
 	if (memcmp(edid, "\x00\xff\xff\xff\xff\xff\xff\x00", 8) == 0)
-		return TRUE;
-	return FALSE;
+		return 1;
+	return 0;
 }
 
 static void decode_lf_string(const uchar *s, int n_chars, char *result)
@@ -100,7 +97,7 @@ static int decode_descriptors(const uchar *edid, MonitorInfo * info)
 		}
 	}
 
-	return TRUE;
+	return 1;
 }
 
 static void decode_check_sum(const uchar *edid, MonitorInfo * info)
@@ -120,7 +117,7 @@ MonitorInfo *decode_edid(const uchar *edid)
 
 	decode_check_sum(edid, info);
 
-	if (!decode_header(edid))
+	if (!is_edid_header(edid))
 		return NULL;
 
 	if (!decode_descriptors(edid, info))

--- a/edid-parse.c
+++ b/edid-parse.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2007 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * on the rights to use, copy, modify, merge, publish, distribute, sub
+ * license, and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Author: Soren Sandmann <sandmann@redhat.com> */
+
+#include "edid.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define TRUE 1
+#define FALSE 0
+
+static int decode_header(const uchar *edid)
+{
+	if (memcmp(edid, "\x00\xff\xff\xff\xff\xff\xff\x00", 8) == 0)
+		return TRUE;
+	return FALSE;
+}
+
+static void decode_lf_string(const uchar *s, int n_chars, char *result)
+{
+	int i;
+	for (i = 0; i < n_chars; ++i)
+	{
+		if (s[i] == 0x0a)
+		{
+			*result++ = '\0';
+			break;
+		}
+		else if (s[i] == 0x00)
+		{
+			/* Convert embedded 0's to spaces */
+			*result++ = ' ';
+		}
+		else
+		{
+			*result++ = s[i];
+		}
+	}
+}
+
+static void decode_display_descriptor(const uchar *desc, MonitorInfo *info)
+{
+	switch (desc[0x03])
+	{
+	case 0xFC:
+		decode_lf_string(desc + 5, 13, info->dsc_product_name);
+		break;
+	case 0xFF:
+		decode_lf_string(desc + 5, 13, info->dsc_serial_number);
+		break;
+	case 0xFE:
+		decode_lf_string(desc + 5, 13, info->dsc_string);
+		break;
+	case 0xFD:
+		/* Range Limits */
+		break;
+	case 0xFB:
+		/* Color Point */
+		break;
+	case 0xFA:
+		/* Timing Identifications */
+		break;
+	case 0xF9:
+		/* Color Management */
+		break;
+	case 0xF8:
+		/* Timing Codes */
+		break;
+	case 0xF7:
+		/* Established Timings */
+		break;
+	case 0x10:
+		break;
+	}
+}
+
+static int decode_descriptors(const uchar *edid, MonitorInfo *info)
+{
+	int i;
+
+	for (i = 0; i < 4; ++i)
+	{
+		int index = 0x36 + i * 18;
+
+		if (edid[index + 0] == 0x00 && edid[index + 1] == 0x00)
+		{
+			decode_display_descriptor(edid + index, info);
+		}
+	}
+
+	return TRUE;
+}
+
+static void decode_check_sum(const uchar *edid, MonitorInfo *info)
+{
+	int i;
+	uchar check = 0;
+
+	for (i = 0; i < 128; ++i)
+		check += edid[i];
+
+	info->checksum = check;
+}
+
+MonitorInfo *decode_edid(const uchar *edid)
+{
+	MonitorInfo *info = calloc(1, sizeof(MonitorInfo));
+
+	decode_check_sum(edid, info);
+
+	if (!decode_header(edid))
+		return NULL;
+
+	if (!decode_descriptors(edid, info))
+		return NULL;
+
+	return info;
+}
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/edid.h
+++ b/edid.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2007 Red Hat, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * on the rights to use, copy, modify, merge, publish, distribute, sub
+ * license, and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* Author: Soren Sandmann <sandmann@redhat.com> */
+
+typedef unsigned char uchar;
+typedef struct MonitorInfo MonitorInfo;
+
+struct MonitorInfo
+{
+	int checksum;
+
+	/* Optional product description */
+	char dsc_serial_number[14];
+	char dsc_product_name[14];
+
+	/* Unspecified ASCII data */
+	char dsc_string[14];
+};
+
+MonitorInfo *decode_edid (const uchar *data);
+
+/**
+ * Local Variables:
+ *  indent-tabs-mode: t
+ *  c-file-style: "linux"
+ * End:
+ */

--- a/edid.h
+++ b/edid.h
@@ -25,8 +25,7 @@
 typedef unsigned char uchar;
 typedef struct MonitorInfo MonitorInfo;
 
-struct MonitorInfo
-{
+struct MonitorInfo {
 	int checksum;
 
 	/* Optional product description */
@@ -37,7 +36,7 @@ struct MonitorInfo
 	char dsc_string[14];
 };
 
-MonitorInfo *decode_edid (const uchar *data);
+MonitorInfo *decode_edid(const uchar *data);
 
 /**
  * Local Variables:

--- a/randr.c
+++ b/randr.c
@@ -21,15 +21,51 @@
  */
 
 #include "xplugd.h"
+#include "edid.h"
 
 static char *con_actions[] = { "connected", "disconnected", "unknown" };
 
+int get_monitor_name(char *name, char *monitor_name)
+{
+	char path[255];
+	FILE *fp = NULL;
+	size_t result;
+	unsigned char edid[128];
+	MonitorInfo *info;
+
+	snprintf(path, sizeof(path), "/sys/class/drm/card0-%s/edid", name);
+	syslog(LOG_DEBUG, "DRM device sysfs path %s\n", path);
+	fp = fopen(path, "rb");
+	if (!fp) {
+		syslog(LOG_ERR, "Failed to find sys path for %s\n", name);
+		return -1;
+	}
+
+	result = fread (edid, 1, sizeof(edid), fp);
+	if (result != 128) {
+		syslog(LOG_NOTICE, "No EDID data found");
+		syslog(LOG_DEBUG, "DRM device sysfs path %s\n", path);
+		return -1;
+	}
+
+	info = decode_edid(edid);
+	if (info == NULL) {
+		syslog(LOG_ERR, "decode failure\n");
+		return -1;
+	}
+
+	syslog(LOG_DEBUG, "MODEL: %s\n", info->dsc_product_name);
+	strncpy(monitor_name, info->dsc_product_name, 14);
+
+	return 0;
+}
 static void handle_event(Display *dpy, XRROutputChangeNotifyEvent *ev)
 {
 	char msg[MSG_LEN];
 	static char old_msg[MSG_LEN] = "";
 	XRROutputInfo *info;
 	XRRScreenResources *resources;
+	char monitor_name[14] = {0};
 
 	resources = XRRGetScreenResources(ev->display, ev->window);
 	if (!resources) {
@@ -71,7 +107,10 @@ static void handle_event(Display *dpy, XRROutputChangeNotifyEvent *ev)
 		}
 	}
 
-	exec("display", info->name, con_actions[info->connection], NULL);
+	if (!strcmp(con_actions[info->connection], "connected"))
+		get_monitor_name(info->name, monitor_name);
+
+	exec("display", info->name, con_actions[info->connection], monitor_name);
 done:
 	XRRFreeOutputInfo(info);
 	XRRFreeScreenResources(resources);

--- a/randr.c
+++ b/randr.c
@@ -41,7 +41,7 @@ int get_monitor_name(char *name, char *monitor_name)
 		return -1;
 	}
 
-	result = fread (edid, 1, sizeof(edid), fp);
+	result = fread(edid, 1, sizeof(edid), fp);
 	if (result != 128) {
 		syslog(LOG_NOTICE, "No EDID data found");
 		syslog(LOG_DEBUG, "DRM device sysfs path %s\n", path);
@@ -49,7 +49,7 @@ int get_monitor_name(char *name, char *monitor_name)
 	}
 
 	info = decode_edid(edid);
-	if (info == NULL) {
+	if (!info) {
 		syslog(LOG_ERR, "decode failure\n");
 		return -1;
 	}

--- a/randr.c
+++ b/randr.c
@@ -56,6 +56,7 @@ int get_monitor_name(char *name, char *monitor_name)
 
 	syslog(LOG_DEBUG, "MODEL: %s\n", info->dsc_product_name);
 	strncpy(monitor_name, info->dsc_product_name, 14);
+	free(info);
 
 	return 0;
 }

--- a/randr.c
+++ b/randr.c
@@ -25,7 +25,7 @@
 
 static char *con_actions[] = { "connected", "disconnected", "unknown" };
 
-int get_monitor_name(char *name, char *monitor_name)
+int get_monitor_name(const char *name, char *monitor_name, size_t len)
 {
 	char path[255];
 	FILE *fp = NULL;
@@ -55,7 +55,7 @@ int get_monitor_name(char *name, char *monitor_name)
 	}
 
 	syslog(LOG_DEBUG, "MODEL: %s\n", info->dsc_product_name);
-	strncpy(monitor_name, info->dsc_product_name, 14);
+	strncpy(monitor_name, info->dsc_product_name, len);
 	free(info);
 
 	return 0;
@@ -109,7 +109,7 @@ static void handle_event(Display *dpy, XRROutputChangeNotifyEvent *ev)
 	}
 
 	if (!strcmp(con_actions[info->connection], "connected"))
-		get_monitor_name(info->name, monitor_name);
+		get_monitor_name(info->name, monitor_name, sizeof(monitor_name));
 
 	exec("display", info->name, con_actions[info->connection], monitor_name);
 done:

--- a/randr.c
+++ b/randr.c
@@ -34,27 +34,26 @@ int get_monitor_name(const char *name, char *monitor_name, size_t len)
 	MonitorInfo *info;
 
 	snprintf(path, sizeof(path), "/sys/class/drm/card0-%s/edid", name);
-	syslog(LOG_DEBUG, "DRM device sysfs path %s\n", path);
+	syslog(LOG_DEBUG, "DRM device sysfs path %s", path);
 	fp = fopen(path, "rb");
 	if (!fp) {
-		syslog(LOG_ERR, "Failed to find sys path for %s\n", name);
+		syslog(LOG_ERR, "Failed to find sys path for %s", name);
 		return -1;
 	}
 
 	result = fread(edid, 1, sizeof(edid), fp);
 	if (result != 128) {
-		syslog(LOG_NOTICE, "No EDID data found");
-		syslog(LOG_DEBUG, "DRM device sysfs path %s\n", path);
+		syslog(LOG_DEBUG, "No EDID data found at DRM device sysfs path %s", path);
 		return -1;
 	}
 
 	info = decode_edid(edid);
 	if (!info) {
-		syslog(LOG_ERR, "decode failure\n");
+		syslog(LOG_ERR, "decode failure");
 		return -1;
 	}
 
-	syslog(LOG_DEBUG, "MODEL: %s\n", info->dsc_product_name);
+	syslog(LOG_DEBUG, "MODEL: %s", info->dsc_product_name);
 	strncpy(monitor_name, info->dsc_product_name, len);
 	free(info);
 


### PR DESCRIPTION
This pull requst adds monitor name to $XPLUGRC as "optional description" (fourth argument).

Monitor name is extracted from the connected monitor's EDID data. If no such data is available for whatever reason (old monitor model, or incorrect header/checksum), an empty string is passed instead.

Tests have only been performed with one monitor connected at a time.