### PR TITLE
Fix EDID extraction for non-VGA displays

### DIFF
--- a/edid.c
+++ b/edid.c
@@ -115,16 +115,12 @@ static void decode_checksum(const unsigned char *edid, struct monitor_info *info
 	info->checksum = check;
 }
 
-struct monitor_info *edid_decode(const unsigned char *edid, size_t len)
+struct monitor_info *edid_decode(const unsigned char *edid)
 {
 	struct monitor_info *info;
 
 	if (!edid) {
 		errno = EINVAL;
-		return NULL;
-	}
-	if (len != 128) {
-		errno = ENODATA;
 		return NULL;
 	}
 

--- a/edid.h
+++ b/edid.h
@@ -33,7 +33,7 @@ struct monitor_info {
 	char dsc_string[14];
 };
 
-struct monitor_info *edid_decode(const unsigned char *data, size_t len);
+struct monitor_info *edid_decode(const unsigned char *data);
 
 /**
  * Local Variables:

--- a/indent.sh
+++ b/indent.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# Don't touch comment content/formatting, only placement.
+# ignore any ~/.indent.pro
+#
+# With the -T <type> we can inform indent about non-ansi types
+# that we've added, so indent doesn't insert spaces in odd places.
+#
+indent -linux									\
+       --ignore-profile								\
+       --preserve-mtime								\
+       --break-after-boolean-operator						\
+       --blank-lines-after-procedures						\
+       --blank-lines-after-declarations						\
+       --dont-break-function-decl-args						\
+       --dont-break-procedure-type						\
+       --leave-preprocessor-space						\
+       --line-length132								\
+       --honour-newlines							\
+       --space-after-if								\
+       --space-after-for							\
+       --space-after-while							\
+       --leave-optional-blank-lines						\
+       --dont-format-comments							\
+       --no-blank-lines-after-commas						\
+       --no-space-after-parentheses						\
+       --no-space-after-casts							\
+       -T size_t -T sigset_t -T timeval_t -T pid_t -T pthread_t -T FILE		\
+       -T time_t -T uint32_t -T uint16_t -T uint8_t -T uchar -T uint -T ulong	\
+       -T xht_t -T xhn_t -T throttletab \
+	-T Timer -T ClientData -T TimerProc 			\
+	-T httpd_sockaddr -T httpd_server -T httpd_conn -T Map -T connecttab	\
+	-T Display \
+	-T XRRScreenResources \
+	-T XRROutputChangeNotifyEvent \
+	-T XEvent \
+	$*

--- a/randr.c
+++ b/randr.c
@@ -88,7 +88,7 @@ static void handle_event(Display *dpy, XRROutputChangeNotifyEvent *ev)
 	static char old_msg[MSG_LEN] = "";
 	XRROutputInfo *info;
 	XRRScreenResources *resources;
-	char monitor_name[14] = {0};
+	char monitor_name[14] = { 0 };
 
 	resources = XRRGetScreenResources(ev->display, ev->window);
 	if (!resources) {
@@ -134,7 +134,7 @@ static void handle_event(Display *dpy, XRROutputChangeNotifyEvent *ev)
 		get_monitor_name(info->name, dpy, resources, monitor_name, sizeof(monitor_name));
 
 	exec("display", info->name, con_actions[info->connection], monitor_name);
-done:
+ done:
 	XRRFreeOutputInfo(info);
 	XRRFreeScreenResources(resources);
 }


### PR DESCRIPTION
EDID extraction was horribly broken and only worked on VGA displays. This PR will fix that by using XRRScreenResources instead of reading from a partially hardcoded sysfs path.

Tested on VGA and HDMI displays.