### PR TITLE
Print more EDID when probing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_HEADER_STDC
 AC_PROG_INSTALL
 
 # Check for required libraries
+AC_SEARCH_LIBS([pow], [m])
 PKG_CHECK_MODULES([X11], [x11])
 PKG_CHECK_MODULES([Xrandr], [xrandr])
 PKG_CHECK_MODULES([Xi], [xi])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS    = xplugd
 
 xplugd_SOURCES  = xplugd.c xplugd.h exec.c input.c randr.c edid.c edid.h
-xplugd_CFLAGS   = -W -Wall -Wextra -std=c99
+xplugd_CFLAGS   = -W -Wall -Wextra -std=c99 -Wno-unused-parameter
 xplugd_CFLAGS  += -D_POSIX_C_SOURCE=200809L -D_BSD_SOURCE -D_DEFAULT_SOURCE
 xplugd_CFLAGS  += $(X11_CFLAGS) $(Xi_CFLAGS) $(Xrandr_CFLAGS)
 xplugd_LDADD    = $(X11_LIBS) $(Xi_LIBS) $(Xrandr_LIBS)

--- a/src/edid.c
+++ b/src/edid.c
@@ -25,7 +25,21 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
+
 #include "edid.h"
+
+static int get_bit(int in, int bit)
+{
+	return (in & (1 << bit)) >> bit;
+}
+
+static int get_bits(int in, int begin, int end)
+{
+	int mask = (1 << (end - begin + 1)) - 1;
+
+	return (in >> begin) & mask;
+}
 
 static int is_edid_header(const unsigned char *edid)
 {
@@ -33,6 +47,279 @@ static int is_edid_header(const unsigned char *edid)
 		return 1;
 
 	return 0;
+}
+
+static int decode_vendor_and_product_identification(const unsigned char *edid, struct monitor_info *info)
+{
+	int is_model_year;
+
+	/* Manufacturer Code */
+	info->manufacturer_code[0] = get_bits(edid[0x08], 2, 6);
+	info->manufacturer_code[1] = get_bits(edid[0x08], 0, 1) << 3;
+	info->manufacturer_code[1] |= get_bits(edid[0x09], 5, 7);
+	info->manufacturer_code[2] = get_bits(edid[0x09], 0, 4);
+	info->manufacturer_code[3] = '\0';
+
+	info->manufacturer_code[0] += 'A' - 1;
+	info->manufacturer_code[1] += 'A' - 1;
+	info->manufacturer_code[2] += 'A' - 1;
+
+	/* Product Code */
+	info->product_code = edid[0x0b] << 8 | edid[0x0a];
+
+	/* Serial Number */
+	info->serial_number = edid[0x0c] | edid[0x0d] << 8 | edid[0x0e] << 16 | edid[0x0f] << 24;
+
+	/* Week and Year */
+	is_model_year = 0;
+	switch (edid[0x10]) {
+	case 0x00:
+		info->production_week = -1;
+		break;
+
+	case 0xff:
+		info->production_week = -1;
+		is_model_year = 1;
+		break;
+
+	default:
+		info->production_week = edid[0x10];
+		break;
+	}
+
+	if (is_model_year) {
+		info->production_year = -1;
+		info->model_year = 1990 + edid[0x11];
+	} else {
+		info->production_year = 1990 + edid[0x11];
+		info->model_year = -1;
+	}
+
+	return 1;
+}
+
+static int decode_edid_version(const unsigned char *edid, struct monitor_info *info)
+{
+	info->major_version = edid[0x12];
+	info->minor_version = edid[0x13];
+
+	return 1;
+}
+
+static int decode_display_parameters(const unsigned char *edid, struct monitor_info *info)
+{
+	/* Digital vs Analog */
+	info->is_digital = get_bit(edid[0x14], 7);
+
+	if (info->is_digital) {
+		int bits;
+
+		static const int bit_depth[8] = {
+			-1, 6, 8, 10, 12, 14, 16, -1
+		};
+
+		static const enum interface interfaces[6] = {
+			UNDEFINED, DVI, HDMI_A, HDMI_B, MDDI, DISPLAY_PORT
+		};
+
+		bits = get_bits(edid[0x14], 4, 6);
+		info->digital.bits_per_primary = bit_depth[bits];
+
+		bits = get_bits(edid[0x14], 0, 3);
+
+		if (bits <= 5)
+			info->digital.interface = interfaces[bits];
+		else
+			info->digital.interface = UNDEFINED;
+	} else {
+		int bits = get_bits(edid[0x14], 5, 6);
+
+		static const double levels[][3] = {
+			{0.7, 0.3, 1.0},
+			{0.714, 0.286, 1.0},
+			{1.0, 0.4, 1.4},
+			{0.7, 0.0, 0.7},
+		};
+
+		info->analog.video_signal_level = levels[bits][0];
+		info->analog.sync_signal_level = levels[bits][1];
+		info->analog.total_signal_level = levels[bits][2];
+
+		info->analog.blank_to_black = get_bit(edid[0x14], 4);
+
+		info->analog.separate_hv_sync = get_bit(edid[0x14], 3);
+		info->analog.composite_sync_on_h = get_bit(edid[0x14], 2);
+		info->analog.composite_sync_on_green = get_bit(edid[0x14], 1);
+
+		info->analog.serration_on_vsync = get_bit(edid[0x14], 0);
+	}
+
+	/* Screen Size / Aspect Ratio */
+	if (edid[0x15] == 0 && edid[0x16] == 0) {
+		info->width_mm = -1;
+		info->height_mm = -1;
+		info->aspect_ratio = -1.0;
+	} else if (edid[0x16] == 0) {
+		info->width_mm = -1;
+		info->height_mm = -1;
+		info->aspect_ratio = 100.0 / (edid[0x15] + 99);
+	} else if (edid[0x15] == 0) {
+		info->width_mm = -1;
+		info->height_mm = -1;
+		info->aspect_ratio = 100.0 / (edid[0x16] + 99);
+		info->aspect_ratio = 1 / info->aspect_ratio;	/* portrait */
+	} else {
+		info->width_mm = 10 * edid[0x15];
+		info->height_mm = 10 * edid[0x16];
+	}
+
+	/* Gamma */
+	if (edid[0x17] == 0xFF)
+		info->gamma = -1.0;
+	else
+		info->gamma = (edid[0x17] + 100.0) / 100.0;
+
+	/* Features */
+	info->standby = get_bit(edid[0x18], 7);
+	info->suspend = get_bit(edid[0x18], 6);
+	info->active_off = get_bit(edid[0x18], 5);
+
+	if (info->is_digital) {
+		info->digital.rgb444 = 1;
+		if (get_bit(edid[0x18], 3))
+			info->digital.ycrcb444 = 1;
+		if (get_bit(edid[0x18], 4))
+			info->digital.ycrcb422 = 1;
+	} else {
+		int bits = get_bits(edid[0x18], 3, 4);
+
+		enum color_type color_type[4] = {
+			MONOCHROME, RGB, OTHER_COLOR, UNDEFINED_COLOR
+		};
+
+		info->analog.color_type = color_type[bits];
+	}
+
+	info->srgb_is_standard = get_bit(edid[0x18], 2);
+
+	/* In 1.3 this is called "has preferred timing" */
+	info->preferred_timing_includes_native = get_bit(edid[0x18], 1);
+
+	/* FIXME: In 1.3 this indicates whether the monitor accepts GTF */
+	info->continuous_frequency = get_bit(edid[0x18], 0);
+	return 1;
+}
+
+static double decode_fraction(int high, int low)
+{
+	double result = 0.0;
+	int i;
+
+	high = (high << 2) | low;
+
+	for (i = 0; i < 10; ++i)
+		result += get_bit(high, i) * pow(2, i - 10);
+
+	return result;
+}
+
+static int decode_color_characteristics(const unsigned char *edid, struct monitor_info *info)
+{
+	info->red_x = decode_fraction(edid[0x1b], get_bits(edid[0x19], 6, 7));
+	info->red_y = decode_fraction(edid[0x1c], get_bits(edid[0x19], 5, 4));
+	info->green_x = decode_fraction(edid[0x1d], get_bits(edid[0x19], 2, 3));
+	info->green_y = decode_fraction(edid[0x1e], get_bits(edid[0x19], 0, 1));
+	info->blue_x = decode_fraction(edid[0x1f], get_bits(edid[0x1a], 6, 7));
+	info->blue_y = decode_fraction(edid[0x20], get_bits(edid[0x1a], 4, 5));
+	info->white_x = decode_fraction(edid[0x21], get_bits(edid[0x1a], 2, 3));
+	info->white_y = decode_fraction(edid[0x22], get_bits(edid[0x1a], 0, 1));
+
+	return 1;
+}
+
+static int decode_established_timings(const unsigned char *edid, struct monitor_info *info)
+{
+	static const struct timing established[][8] = {
+		{
+			{800, 600, 60},
+			{800, 600, 56},
+			{640, 480, 75},
+			{640, 480, 72},
+			{640, 480, 67},
+			{640, 480, 60},
+			{720, 400, 88},
+			{720, 400, 70}
+		},
+		{
+			{1280, 1024, 75},
+			{1024, 768, 75},
+			{1024, 768, 70},
+			{1024, 768, 60},
+			{1024, 768, 87},
+			{832, 624, 75},
+			{800, 600, 75},
+			{800, 600, 72}
+		},
+		{
+			{0, 0, 0},
+			{0, 0, 0},
+			{0, 0, 0},
+			{0, 0, 0},
+			{0, 0, 0},
+			{0, 0, 0},
+			{0, 0, 0},
+			{1152, 870, 75}
+		},
+	};
+
+	int i, j, idx;
+
+	idx = 0;
+	for (i = 0; i < 3; ++i) {
+		for (j = 0; j < 8; ++j) {
+			int byte = edid[0x23 + i];
+
+			if (get_bit(byte, j) && established[i][j].frequency != 0)
+				info->established[idx++] = established[i][j];
+		}
+	}
+	return 1;
+}
+
+static int decode_standard_timings(const unsigned char *edid, struct monitor_info *info)
+{
+	int i;
+
+	for (i = 0; i < 8; i++) {
+		int first = edid[0x26 + 2 * i];
+		int second = edid[0x27 + 2 * i];
+
+		if (first != 0x01 && second != 0x01) {
+			int w = 8 * (first + 31);
+			int h;
+
+			switch (get_bits(second, 6, 7)) {
+			case 0x00:
+				h = (w / 16) * 10;
+				break;
+			case 0x01:
+				h = (w / 4) * 3;
+				break;
+			case 0x02:
+				h = (w / 5) * 4;
+				break;
+			case 0x03:
+				h = (w / 16) * 9;
+				break;
+			}
+
+			info->standard[i].width = w;
+			info->standard[i].height = h;
+			info->standard[i].frequency = get_bits(second, 0, 5) + 60;
+		}
+	}
+
+	return 1;
 }
 
 static void decode_lf_string(const unsigned char *s, int n_chars, char *result)
@@ -95,14 +382,79 @@ static void decode_display_descriptor(const unsigned char *desc, struct monitor_
 	}
 }
 
-static void decode_descriptors(const unsigned char *edid, struct monitor_info *info)
+static void decode_detailed_timing(const unsigned char *timing, struct detailed_timing * detailed)
 {
-	for (int i = 0; i < 4; ++i) {
+	int bits;
+
+	enum stereo_type stereo[] = {
+		NO_STEREO, NO_STEREO, FIELD_RIGHT, FIELD_LEFT,
+		TWO_WAY_RIGHT_ON_EVEN, TWO_WAY_LEFT_ON_EVEN,
+		FOUR_WAY_INTERLEAVED, SIDE_BY_SIDE
+	};
+
+	detailed->pixel_clock = (timing[0x00] | timing[0x01] << 8) * 10000;
+	detailed->h_addr = timing[0x02] | ((timing[0x04] & 0xf0) << 4);
+	detailed->h_blank = timing[0x03] | ((timing[0x04] & 0x0f) << 8);
+	detailed->v_addr = timing[0x05] | ((timing[0x07] & 0xf0) << 4);
+	detailed->v_blank = timing[0x06] | ((timing[0x07] & 0x0f) << 8);
+	detailed->h_front_porch = timing[0x08] | get_bits(timing[0x0b], 6, 7) << 8;
+	detailed->h_sync = timing[0x09] | get_bits(timing[0x0b], 4, 5) << 8;
+	detailed->v_front_porch = get_bits(timing[0x0a], 4, 7) | get_bits(timing[0x0b], 2, 3) << 4;
+	detailed->v_sync = get_bits(timing[0x0a], 0, 3) | get_bits(timing[0x0b], 0, 1) << 4;
+	detailed->width_mm = timing[0x0c] | get_bits(timing[0x0e], 4, 7) << 8;
+	detailed->height_mm = timing[0x0d] | get_bits(timing[0x0e], 0, 3) << 8;
+	detailed->right_border = timing[0x0f];
+	detailed->top_border = timing[0x10];
+
+	detailed->interlaced = get_bit(timing[0x11], 7);
+
+	/* Stereo */
+	bits = get_bits(timing[0x11], 5, 6) << 1 | get_bit(timing[0x11], 0);
+	detailed->stereo = stereo[bits];
+
+	/* Sync */
+	bits = timing[0x11];
+
+	detailed->digital_sync = get_bit(bits, 4);
+	if (detailed->digital_sync) {
+		detailed->digital.composite = !get_bit(bits, 3);
+
+		if (detailed->digital.composite) {
+			detailed->digital.serrations = get_bit(bits, 2);
+			detailed->digital.negative_vsync = 0;
+		} else {
+			detailed->digital.serrations = 0;
+			detailed->digital.negative_vsync = !get_bit(bits, 2);
+		}
+
+		detailed->digital.negative_hsync = !get_bit(bits, 0);
+	} else {
+		detailed->analog.bipolar = get_bit(bits, 3);
+		detailed->analog.serrations = get_bit(bits, 2);
+		detailed->analog.sync_on_green = !get_bit(bits, 1);
+	}
+}
+
+static int decode_descriptors(const unsigned char *edid, struct monitor_info *info)
+{
+	int i;
+	int timing_idx;
+
+	timing_idx = 0;
+
+	for (i = 0; i < 4; ++i) {
 		int index = 0x36 + i * 18;
 
-		if (edid[index + 0] == 0x00 && edid[index + 1] == 0x00)
+		if (edid[index + 0] == 0x00 && edid[index + 1] == 0x00) {
 			decode_display_descriptor(edid + index, info);
+		} else {
+			decode_detailed_timing(edid + index, &(info->detailed_timings[timing_idx++]));
+		}
 	}
+
+	info->n_detailed_timings = timing_idx;
+
+	return 1;
 }
 
 static void decode_checksum(const unsigned char *edid, struct monitor_info *info)
@@ -117,28 +469,48 @@ static void decode_checksum(const unsigned char *edid, struct monitor_info *info
 
 struct monitor_info *edid_decode(const unsigned char *edid)
 {
-	struct monitor_info *info;
-
 	if (!edid) {
 		errno = EINVAL;
 		return NULL;
 	}
 
+	struct monitor_info *info;
 	info = calloc(1, sizeof(struct monitor_info));
 	if (!info)
 		return NULL;
 
 	decode_checksum(edid, info);
 
-	if (!is_edid_header(edid)) {
-		free(info);
-		errno = ENOENT;
-		return NULL;
-	}
+	if (!is_edid_header(edid))
+		goto error;
 
-	decode_descriptors(edid, info);
+	if (!decode_vendor_and_product_identification(edid, info))
+		goto error;
+
+	if (!decode_edid_version(edid, info))
+		goto error;
+
+	if (!decode_display_parameters(edid, info))
+		goto error;
+
+	if (!decode_color_characteristics(edid, info))
+		goto error;
+
+	if (!decode_established_timings(edid, info))
+		goto error;
+
+	if (!decode_standard_timings(edid, info))
+		goto error;
+
+	if (!decode_descriptors(edid, info))
+		goto error;
 
 	return info;
+
+error:
+	free(info);
+	errno = ENOENT;
+	return NULL;
 }
 
 /**

--- a/src/edid.c
+++ b/src/edid.c
@@ -38,14 +38,12 @@ int print_edid_heading(const char *prefix, const char *data, const char *postfix
 {
 	if (data) {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%s%s%s",
-		       prefix, (strlen(data) > 0) ? data : "N/A", postfix);
-	}
-	else {
+		printf("%s%s%s", prefix, (strlen(data) > 0) ? data : "N/A", postfix);
+	} else {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s%s%s", KEYWORD_LEN,
-		       prefix, "N/A",  postfix);
+		printf("%-*s%s%s", KEYWORD_LEN, prefix, "N/A", postfix);
 	}
+
 	return 0;
 }
 
@@ -53,14 +51,12 @@ int print_edid_str(const char *prefix, const char *data, const char *postfix, in
 {
 	if (data) {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %s%s", KEYWORD_LEN,
-		       prefix, (strlen(data) > 0) ? data : "N/A", postfix);
-	}
-	else {
+		printf("%-*s: %s%s", KEYWORD_LEN, prefix, (strlen(data) > 0) ? data : "N/A", postfix);
+	} else {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %s%s", KEYWORD_LEN,
-		       prefix, "N/A",  postfix);
+		printf("%-*s: %s%s", KEYWORD_LEN, prefix, "N/A", postfix);
 	}
+
 	return 0;
 }
 
@@ -68,14 +64,12 @@ int print_edid_bool(const char *prefix, int data, const char *postfix, int level
 {
 	if (data) {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %s%s", KEYWORD_LEN,
-		       prefix, (data ? "Yes" : "No"), postfix);
-	}
-	else {
+		printf("%-*s: %s%s", KEYWORD_LEN, prefix, (data ? "Yes" : "No"), postfix);
+	} else {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %s%s", KEYWORD_LEN,
-		       prefix, "N/A",  postfix);
+		printf("%-*s: %s%s", KEYWORD_LEN, prefix, "N/A", postfix);
 	}
+
 	return 0;
 }
 
@@ -83,14 +77,12 @@ int print_edid_integer(const char *prefix, int data, const char *postfix, int le
 {
 	if (data && data > 0) {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %d%s", KEYWORD_LEN,
-		       prefix, data,  postfix);
-	}
-	else {
+		printf("%-*s: %d%s", KEYWORD_LEN, prefix, data, postfix);
+	} else {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %s%s", KEYWORD_LEN,
-		       prefix, "N/A",  postfix);
+		printf("%-*s: %s%s", KEYWORD_LEN, prefix, "N/A", postfix);
 	}
+
 	return 0;
 }
 
@@ -98,14 +90,12 @@ int print_edid_double(const char *prefix, double data, const char *postfix, int 
 {
 	if (data && data > 0) {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %G%s", KEYWORD_LEN,
-		       prefix, data,  postfix);
-	}
-	else {
+		printf("%-*s: %G%s", KEYWORD_LEN, prefix, data, postfix);
+	} else {
 		printf("%-*s", (level * TAB_LEN), "");
-		printf("%-*s: %s%s", KEYWORD_LEN,
-		       prefix, "N/A",  postfix);
+		printf("%-*s: %s%s", KEYWORD_LEN, prefix, "N/A", postfix);
 	}
+
 	return 0;
 }
 
@@ -287,6 +277,7 @@ static int decode_display_parameters(const unsigned char *edid, struct monitor_i
 
 	/* FIXME: In 1.3 this indicates whether the monitor accepts GTF */
 	info->continuous_frequency = get_bit(edid[0x18], 0);
+
 	return 1;
 }
 
@@ -363,6 +354,7 @@ static int decode_established_timings(const unsigned char *edid, struct monitor_
 				info->established[idx++] = established[i][j];
 		}
 	}
+
 	return 1;
 }
 
@@ -472,20 +464,30 @@ static void decode_detailed_timing(const unsigned char *timing, struct detailed_
 		FOUR_WAY_INTERLEAVED, SIDE_BY_SIDE
 	};
 
-	detailed->pixel_clock = (timing[0x00] | timing[0x01] << 8) * 10000;
-	detailed->h_addr = timing[0x02] | ((timing[0x04] & 0xf0) << 4);
-	detailed->h_blank = timing[0x03] | ((timing[0x04] & 0x0f) << 8);
-	detailed->v_addr = timing[0x05] | ((timing[0x07] & 0xf0) << 4);
-	detailed->v_blank = timing[0x06] | ((timing[0x07] & 0x0f) << 8);
-	detailed->h_front_porch = timing[0x08] | get_bits(timing[0x0b], 6, 7) << 8;
-	detailed->h_sync = timing[0x09] | get_bits(timing[0x0b], 4, 5) << 8;
-	detailed->v_front_porch = get_bits(timing[0x0a], 4, 7) | get_bits(timing[0x0b], 2, 3) << 4;
-	detailed->v_sync = get_bits(timing[0x0a], 0, 3) | get_bits(timing[0x0b], 0, 1) << 4;
-	detailed->width_mm = timing[0x0c] | get_bits(timing[0x0e], 4, 7) << 8;
-	detailed->height_mm = timing[0x0d] | get_bits(timing[0x0e], 0, 3) << 8;
+	detailed->pixel_clock = (timing[0x00] |
+				 timing[0x01] << 8) * 10000;
+	detailed->h_addr = (timing[0x02] |
+			    ((timing[0x04] & 0xf0) << 4));
+	detailed->h_blank = (timing[0x03] |
+			     ((timing[0x04] & 0x0f) << 8));
+	detailed->v_addr = (timing[0x05] |
+			    ((timing[0x07] & 0xf0) << 4));
+	detailed->v_blank = (timing[0x06] |
+			     ((timing[0x07] & 0x0f) << 8));
+	detailed->h_front_porch = (timing[0x08] |
+				   get_bits(timing[0x0b], 6, 7) << 8);
+	detailed->h_sync = (timing[0x09] |
+			    get_bits(timing[0x0b], 4, 5) << 8);
+	detailed->v_front_porch = (get_bits(timing[0x0a], 4, 7) |
+				   get_bits(timing[0x0b], 2, 3) << 4);
+	detailed->v_sync = (get_bits(timing[0x0a], 0, 3) |
+			    get_bits(timing[0x0b], 0, 1) << 4);
+	detailed->width_mm = (timing[0x0c] |
+			      get_bits(timing[0x0e], 4, 7) << 8);
+	detailed->height_mm = (timing[0x0d] |
+			       get_bits(timing[0x0e], 0, 3) << 8);
 	detailed->right_border = timing[0x0f];
 	detailed->top_border = timing[0x10];
-
 	detailed->interlaced = get_bit(timing[0x11], 7);
 
 	/* Stereo */
@@ -555,6 +557,7 @@ struct monitor_info *edid_decode(const unsigned char *edid)
 	}
 
 	struct monitor_info *info;
+
 	info = calloc(1, sizeof(struct monitor_info));
 	if (!info)
 		return NULL;
@@ -590,6 +593,7 @@ struct monitor_info *edid_decode(const unsigned char *edid)
 error:
 	free(info);
 	errno = ENOENT;
+
 	return NULL;
 }
 

--- a/src/edid.c
+++ b/src/edid.c
@@ -22,12 +22,92 @@
 
 /* Author: Soren Sandmann <sandmann@redhat.com> */
 
+#include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
 
 #include "edid.h"
+
+#define TAB_LEN 8
+#define KEYWORD_LEN 13 // Max length of longest keyword (Currently Aspect Ratio)
+
+/* TODO: Turn these print_edid_* functions into macros? Horrible code duplication! :/ */
+int print_edid_heading(const char *prefix, const char *data, const char *postfix, int level)
+{
+	if (data) {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%s%s%s",
+		       prefix, (strlen(data) > 0) ? data : "N/A", postfix);
+	}
+	else {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s%s%s", KEYWORD_LEN,
+		       prefix, "N/A",  postfix);
+	}
+	return 0;
+}
+
+int print_edid_str(const char *prefix, const char *data, const char *postfix, int level)
+{
+	if (data) {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %s%s", KEYWORD_LEN,
+		       prefix, (strlen(data) > 0) ? data : "N/A", postfix);
+	}
+	else {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %s%s", KEYWORD_LEN,
+		       prefix, "N/A",  postfix);
+	}
+	return 0;
+}
+
+int print_edid_bool(const char *prefix, int data, const char *postfix, int level)
+{
+	if (data) {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %s%s", KEYWORD_LEN,
+		       prefix, (data ? "Yes" : "No"), postfix);
+	}
+	else {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %s%s", KEYWORD_LEN,
+		       prefix, "N/A",  postfix);
+	}
+	return 0;
+}
+
+int print_edid_integer(const char *prefix, int data, const char *postfix, int level)
+{
+	if (data && data > 0) {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %d%s", KEYWORD_LEN,
+		       prefix, data,  postfix);
+	}
+	else {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %s%s", KEYWORD_LEN,
+		       prefix, "N/A",  postfix);
+	}
+	return 0;
+}
+
+int print_edid_double(const char *prefix, double data, const char *postfix, int level)
+{
+	if (data && data > 0) {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %G%s", KEYWORD_LEN,
+		       prefix, data,  postfix);
+	}
+	else {
+		printf("%-*s", (level * TAB_LEN), "");
+		printf("%-*s: %s%s", KEYWORD_LEN,
+		       prefix, "N/A",  postfix);
+	}
+	return 0;
+}
 
 static int get_bit(int in, int bit)
 {

--- a/src/edid.c
+++ b/src/edid.c
@@ -464,31 +464,20 @@ static void decode_detailed_timing(const unsigned char *timing, struct detailed_
 		FOUR_WAY_INTERLEAVED, SIDE_BY_SIDE
 	};
 
-	detailed->pixel_clock = (timing[0x00] |
-				 timing[0x01] << 8) * 10000;
-	detailed->h_addr = (timing[0x02] |
-			    ((timing[0x04] & 0xf0) << 4));
-	detailed->h_blank = (timing[0x03] |
-			     ((timing[0x04] & 0x0f) << 8));
-	detailed->v_addr = (timing[0x05] |
-			    ((timing[0x07] & 0xf0) << 4));
-	detailed->v_blank = (timing[0x06] |
-			     ((timing[0x07] & 0x0f) << 8));
-	detailed->h_front_porch = (timing[0x08] |
-				   get_bits(timing[0x0b], 6, 7) << 8);
-	detailed->h_sync = (timing[0x09] |
-			    get_bits(timing[0x0b], 4, 5) << 8);
-	detailed->v_front_porch = (get_bits(timing[0x0a], 4, 7) |
-				   get_bits(timing[0x0b], 2, 3) << 4);
-	detailed->v_sync = (get_bits(timing[0x0a], 0, 3) |
-			    get_bits(timing[0x0b], 0, 1) << 4);
-	detailed->width_mm = (timing[0x0c] |
-			      get_bits(timing[0x0e], 4, 7) << 8);
-	detailed->height_mm = (timing[0x0d] |
-			       get_bits(timing[0x0e], 0, 3) << 8);
-	detailed->right_border = timing[0x0f];
-	detailed->top_border = timing[0x10];
-	detailed->interlaced = get_bit(timing[0x11], 7);
+	detailed->pixel_clock	= (timing[0x00] | timing[0x01] << 8) * 10000;
+	detailed->h_addr	= timing[0x02]	| ((timing[0x04] & 0xf0) << 4);
+	detailed->h_blank	= timing[0x03]	| ((timing[0x04] & 0x0f) << 8);
+	detailed->v_addr	= timing[0x05]	| ((timing[0x07] & 0xf0) << 4);
+	detailed->v_blank	= timing[0x06]	| ((timing[0x07] & 0x0f) << 8);
+	detailed->h_front_porch = timing[0x08]	| get_bits(timing[0x0b], 6, 7) << 8;
+	detailed->h_sync	= timing[0x09]	| get_bits(timing[0x0b], 4, 5) << 8;
+	detailed->v_front_porch = get_bits(timing[0x0a], 4, 7) | get_bits(timing[0x0b], 2, 3) << 4;
+	detailed->v_sync	= get_bits(timing[0x0a], 0, 3) | get_bits(timing[0x0b], 0, 1) << 4;
+	detailed->width_mm	= timing[0x0c]	| get_bits(timing[0x0e], 4, 7) << 8;
+	detailed->height_mm	= timing[0x0d]	| get_bits(timing[0x0e], 0, 3) << 8;
+	detailed->right_border	= timing[0x0f];
+	detailed->top_border	= timing[0x10];
+	detailed->interlaced	= get_bit(timing[0x11], 7);
 
 	/* Stereo */
 	bits = get_bits(timing[0x11], 5, 6) << 1 | get_bit(timing[0x11], 0);

--- a/src/edid.h
+++ b/src/edid.h
@@ -22,7 +22,7 @@
 
 /* Author: Soren Sandmann <sandmann@redhat.com> */
 
-enum  interface {
+enum interface {
 	UNDEFINED,
 	DVI,
 	HDMI_A,
@@ -153,14 +153,11 @@ struct monitor_info {
 	struct timing established[24];	/* Terminated by 0x0x0 */
 	struct timing standard[8];
 
+	/* If monitor has a preferred mode, it is the first one (whether it has,
+	 * is determined by the preferred_timing_includes bit.
+	 */
 	int n_detailed_timings;
-	struct detailed_timing detailed_timings[4];	/* If monitor has a preferred
-							 * mode, it is the first one
-							 * (whether it has, is
-							 * determined by the
-							 * preferred_timing_includes
-							 * bit.
-							 */
+	struct detailed_timing detailed_timings[4];
 
 	/* Optional product description */
 	char dsc_serial_number[14];

--- a/src/edid.h
+++ b/src/edid.h
@@ -22,15 +22,150 @@
 
 /* Author: Soren Sandmann <sandmann@redhat.com> */
 
+enum  interface {
+	UNDEFINED,
+	DVI,
+	HDMI_A,
+	HDMI_B,
+	MDDI,
+	DISPLAY_PORT
+};
+
+enum color_type {
+	UNDEFINED_COLOR,
+	MONOCHROME,
+	RGB,
+	OTHER_COLOR
+};
+
+enum stereo_type {
+	NO_STEREO,
+	FIELD_RIGHT,
+	FIELD_LEFT,
+	TWO_WAY_RIGHT_ON_EVEN,
+	TWO_WAY_LEFT_ON_EVEN,
+	FOUR_WAY_INTERLEAVED,
+	SIDE_BY_SIDE
+};
+
+struct timing {
+	int width;
+	int height;
+	int frequency;
+};
+
+struct detailed_timing {
+	int pixel_clock;
+	int h_addr;
+	int h_blank;
+	int h_sync;
+	int h_front_porch;
+	int v_addr;
+	int v_blank;
+	int v_sync;
+	int v_front_porch;
+	int width_mm;
+	int height_mm;
+	int right_border;
+	int top_border;
+	int interlaced;
+	enum stereo_type stereo;
+
+	int digital_sync;
+	union {
+		struct {
+			int bipolar;
+			int serrations;
+			int sync_on_green;
+		} analog;
+
+		struct {
+			int composite;
+			int serrations;
+			int negative_vsync;
+			int negative_hsync;
+		} digital;
+	};
+};
+
 struct monitor_info {
 	int checksum;
+	char manufacturer_code[4];
+	int product_code;
+	unsigned int serial_number;
+
+	int production_week;	/* -1 if not specified */
+	int production_year;	/* -1 if not specified */
+	int model_year;		/* -1 if not specified */
+
+	int major_version;
+	int minor_version;
+
+	int is_digital;
+
+	union {
+		struct {
+			int bits_per_primary;
+			enum interface interface;
+			int rgb444;
+			int ycrcb444;
+			int ycrcb422;
+		} digital;
+
+		struct {
+			double video_signal_level;
+			double sync_signal_level;
+			double total_signal_level;
+
+			int blank_to_black;
+
+			int separate_hv_sync;
+			int composite_sync_on_h;
+			int composite_sync_on_green;
+			int serration_on_vsync;
+			enum color_type color_type;
+		} analog;
+	};
+
+	int width_mm;		/* -1 if not specified */
+	int height_mm;		/* -1 if not specified */
+	double aspect_ratio;	/* -1.0 if not specififed */
+
+	double gamma;		/* -1.0 if not specified */
+
+	int standby;
+	int suspend;
+	int active_off;
+
+	int srgb_is_standard;
+	int preferred_timing_includes_native;
+	int continuous_frequency;
+
+	double red_x;
+	double red_y;
+	double green_x;
+	double green_y;
+	double blue_x;
+	double blue_y;
+	double white_x;
+	double white_y;
+
+	struct timing established[24];	/* Terminated by 0x0x0 */
+	struct timing standard[8];
+
+	int n_detailed_timings;
+	struct detailed_timing detailed_timings[4];	/* If monitor has a preferred
+							 * mode, it is the first one
+							 * (whether it has, is
+							 * determined by the
+							 * preferred_timing_includes
+							 * bit.
+							 */
 
 	/* Optional product description */
 	char dsc_serial_number[14];
 	char dsc_product_name[14];
-
-	/* Unspecified ASCII data */
-	char dsc_string[14];
+	char dsc_string[14];	/* Unspecified ASCII data */
 };
 
 struct monitor_info *edid_decode(const unsigned char *data);

--- a/src/edid.h
+++ b/src/edid.h
@@ -153,7 +153,8 @@ struct monitor_info {
 	struct timing established[24];	/* Terminated by 0x0x0 */
 	struct timing standard[8];
 
-	/* If monitor has a preferred mode, it is the first one (whether it has,
+	/*
+	 * If monitor has a preferred mode, it is the first one (whether it has,
 	 * is determined by the preferred_timing_includes bit.
 	 */
 	int n_detailed_timings;

--- a/src/edid.h
+++ b/src/edid.h
@@ -167,6 +167,11 @@ struct monitor_info {
 	char dsc_product_name[14];
 	char dsc_string[14];	/* Unspecified ASCII data */
 };
+int print_edid_heading(const char *prefix, const char *data, const char *postfix, int level);
+int print_edid_str(const char *prefix, const char *data, const char *postfix, int level);
+int print_edid_bool(const char *prefix, int data, const char *postfix, int level);
+int print_edid_integer(const char *prefix, int data, const char *postfix, int level);
+int print_edid_double(const char *prefix, double data, const char *postfix, int level);
 
 struct monitor_info *edid_decode(const unsigned char *data);
 

--- a/src/input.c
+++ b/src/input.c
@@ -30,46 +30,46 @@
 #define UINT_MAX_STRING EXPAND_STRINGIFY(UINT_MAX)
 
 struct pair {
-    int key;
-    char * value;
+	int key;
+	char *value;
 };
 
 const struct pair device_types[] = {
-    T(XIMasterPointer),
-    T(XIMasterKeyboard),
-    { XISlavePointer,  "pointer" },
-    { XISlaveKeyboard, "keyboard" },
-    T(XIFloatingSlave),
-    T_END
+	T(XIMasterPointer),
+	T(XIMasterKeyboard),
+	{XISlavePointer, "pointer"},
+	{XISlaveKeyboard, "keyboard"},
+	T(XIFloatingSlave),
+	T_END
 };
 
 const struct pair changes[] = {
-    T(XIMasterAdded),
-    T(XIMasterRemoved),
-    T(XISlaveAdded),
-    T(XISlaveRemoved),
-    T(XISlaveAttached),
-    T(XISlaveDetached),
-    { XIDeviceEnabled,  "connected"    },
-    { XIDeviceDisabled, "disconnected" },
-    T_END
+	T(XIMasterAdded),
+	T(XIMasterRemoved),
+	T(XISlaveAdded),
+	T(XISlaveRemoved),
+	T(XISlaveAttached),
+	T(XISlaveDetached),
+	{XIDeviceEnabled, "connected"},
+	{XIDeviceDisabled, "disconnected"},
+	T_END
 };
 
 static int xi_opcode = -1;
 
 static const struct pair *map(int key, const struct pair *table, bool strict)
 {
-    if (!table)
-	    return NULL;
+	if (!table)
+		return NULL;
 
-    while (table->value) {
-	    if ((!strict && (table->key & key)) || (table->key == key))
-		    return table;
+	while (table->value) {
+		if ((!strict && (table->key & key)) || (table->key == key))
+			return table;
 
-	    table++;
-    }
+		table++;
+	}
 
-    return NULL;
+	return NULL;
 }
 
 static int handle_device(int id, int type, int flags, char *name)
@@ -100,23 +100,23 @@ static int handle_device(int id, int type, int flags, char *name)
 
 static char *get_device_name(Display *display, int deviceid)
 {
-        XIDeviceInfo *info;
-        int i, num_devices;
-        char *name = NULL;
+	XIDeviceInfo *info;
+	int i, num_devices;
+	char *name = NULL;
 
-        info = XIQueryDevice(display, XIAllDevices, &num_devices);
+	info = XIQueryDevice(display, XIAllDevices, &num_devices);
 	if (!info)
 		return NULL;
 
-        for (i = 0; i < num_devices; i++) {
+	for (i = 0; i < num_devices; i++) {
 		if (info[i].deviceid == deviceid) {
 			name = strdup(info[i].name);
 			break;
 		}
-        }
-        XIFreeDeviceInfo(info);
+	}
+	XIFreeDeviceInfo(info);
 
-        return name;
+	return name;
 }
 
 static void handle_event(XIHierarchyEvent *event)
@@ -155,7 +155,7 @@ int input_init(Display *dpy)
 
 	mask.deviceid = XIAllDevices;
 	mask.mask_len = XIMaskLen(XI_LASTEVENT);
-	mask.mask     = calloc(mask.mask_len, sizeof(char));
+	mask.mask = calloc(mask.mask_len, sizeof(char));
 	if (!mask.mask) {
 		syslog(LOG_ERR, "Failed initializing X input module: %s", strerror(errno));
 		exit(1);

--- a/src/randr.c
+++ b/src/randr.c
@@ -50,12 +50,10 @@ static struct monitor_info *edid_info(Display *dpy, XID output, Atom prop)
 	int actual_format;
 
 	XRRGetOutputProperty(dpy, output, prop, 0, 128, False, False,
-			     AnyPropertyType, &actual_type, &actual_format,
-			     &nitems, &bytes_after, &data);
+			     AnyPropertyType, &actual_type, &actual_format, &nitems, &bytes_after, &data);
 
 	if (nitems < 128) {
-		syslog(LOG_INFO,
-		       "Not enough EDID data found.  Need at least 128 bytes, got %lu bytes", nitems);
+		syslog(LOG_INFO, "Not enough EDID data found.  Need at least 128 bytes, got %lu bytes", nitems);
 		return NULL;
 	}
 
@@ -97,8 +95,8 @@ static void edid_desc(Display *dpy, XRRScreenResources *res, const char *output,
 		return;
 	}
 
-	syslog(LOG_DEBUG, "MODEL: %s S/N: %s EXTRA: %s", info->dsc_product_name,
-	       info->dsc_serial_number, info->dsc_string);
+	syslog(LOG_DEBUG, "MODEL: %s S/N: %s EXTRA: %s",
+	       info->dsc_product_name, info->dsc_serial_number, info->dsc_string);
 	strncpy(buf, info->dsc_product_name, len);
 	free(info);
 }
@@ -155,7 +153,7 @@ static void handle_event(Display *dpy, XRROutputChangeNotifyEvent *ev)
 		edid_desc(dpy, res, info->name, desc, sizeof(desc));
 
 	exec("display", info->name, con_actions[info->connection], desc);
- done:
+done:
 	XRRFreeOutputInfo(info);
 	XRRFreeScreenResources(res);
 }
@@ -236,8 +234,8 @@ int randr_probe(Display *dpy)
 			}
 
 			char tmp[10];
-			snprintf(tmp, sizeof(tmp), "%d.%d",
-				 info->major_version, info->minor_version);
+
+			snprintf(tmp, sizeof(tmp), "%d.%d", info->major_version, info->minor_version);
 			print_edid_str("EDID Version", tmp, "\n", 1);
 			break;
 		}

--- a/src/randr.c
+++ b/src/randr.c
@@ -26,6 +26,22 @@
 
 static char *con_actions[] = { "connected", "disconnected", "unknown" };
 
+static char color_type_names[4][16] = {
+	"Undefined",
+	"Monochrome",
+	"RGB",
+	"Other"
+};
+
+static char iface_type_names[6][16] = {
+	"Undefined",
+	"DVI",
+	"HDMI-A",
+	"HDMI-B",
+	"MDDI",
+	"Display Port"
+};
+
 static struct monitor_info *edid_info(Display *dpy, XID output, Atom prop)
 {
 	unsigned long nitems, bytes_after;
@@ -191,15 +207,38 @@ int randr_probe(Display *dpy)
 				break;
 			}
 
-			printf("%s\n"
-			       "\tModel  : %s\n"
-			       "\tS/N    : %s\n"
-			       "\tExtra  : %s\n"
-			       "\n",
-			       output_info->name,
-			       info->dsc_product_name,
-			       info->dsc_serial_number,
-			       info->dsc_string);
+			print_edid_heading("", output_info->name, "\n", 0);
+			print_edid_str("Model", info->dsc_product_name, "\n", 1);
+			print_edid_str("Serial Nr.", info->dsc_serial_number, "\n", 1);
+			print_edid_integer("Width", info->width_mm, "\n", 1);
+			print_edid_integer("Height", info->height_mm, "\n", 1);
+			print_edid_double("Aspect Ratio", info->aspect_ratio, "\n", 1);
+			print_edid_double("Gamma", info->gamma, "\n", 1);
+			print_edid_integer("Prod. Year", info->production_year, "\n", 1);
+			print_edid_integer("Prod. Week", info->production_week, "\n", 1);
+			print_edid_integer("Model Year", info->model_year, "\n", 1);
+			print_edid_str("Extra", info->dsc_string, "\n", 1);
+
+			print_edid_heading("", "DPMS", "\n", 1);
+			print_edid_bool("Standby", info->standby, "\n", 2);
+			print_edid_bool("Suspend", info->suspend, "\n", 2);
+			print_edid_bool("Active Off", info->active_off, "\n", 2);
+
+			if (info->is_digital) {
+				print_edid_str("Interface", iface_type_names[info->digital.interface], "\n", 1);
+				print_edid_heading("", "Display Type (digital)", "\n", 1);
+				print_edid_bool("RGB 4:4:4", info->digital.rgb444, "\n", 2);
+				print_edid_bool("YCrCb 4:4:4", info->digital.ycrcb444, "\n", 2);
+				print_edid_bool("YCrCb 4:2:2", info->digital.ycrcb422, "\n", 2);
+			} else {
+				print_edid_heading("", "Display Type (analog)", "\n", 1);
+				print_edid_str("", color_type_names[info->analog.color_type], "\n", 2);
+			}
+
+			char tmp[10];
+			snprintf(tmp, sizeof(tmp), "%d.%d",
+				 info->major_version, info->minor_version);
+			print_edid_str("EDID Version", tmp, "\n", 1);
 			break;
 		}
 	}

--- a/src/xplugd.c
+++ b/src/xplugd.c
@@ -45,12 +45,14 @@ static char *rcfile(char *arg)
 #else
 	/* Simple homegrown replacement that at least handles leading ~/ */
 	if (!strncmp(arg, "~/", 2)) {
-		const char *home;
+		char *home = NULL;
+		char *arg_tmp = strdup(arg);
 
 		home = getenv("HOME");
 		if (home) {
-			memmove(arg + strlen(home), arg, strlen(arg));
-			memcpy(arg, home, strlen(home));
+			memmove(arg_tmp + strlen(home)-1, arg_tmp, strlen(arg_tmp));
+			memcpy(arg_tmp, home, strlen(home));
+			arg = arg_tmp;
 		}
 	}
 #endif

--- a/src/xplugd.c
+++ b/src/xplugd.c
@@ -26,7 +26,7 @@
 #include <glob.h>
 #include "xplugd.h"
 
-int   loglevel = LOG_NOTICE;
+int loglevel = LOG_NOTICE;
 char *cmd;
 char *prognm;
 
@@ -111,15 +111,15 @@ static int version(void)
 
 static char *progname(char *arg0)
 {
-       char *nm;
+	char *nm;
 
-       nm = strrchr(arg0, '/');
-       if (nm)
-	       nm++;
-       else
-	       nm = arg0;
+	nm = strrchr(arg0, '/');
+	if (nm)
+		nm++;
+	else
+		nm = arg0;
 
-       return nm;
+	return nm;
 }
 
 int main(int argc, char *argv[])

--- a/src/xplugd.c
+++ b/src/xplugd.c
@@ -39,7 +39,7 @@ static char *rcfile(char *arg)
 	if (!arg)
 		arg = XPLUGRC;
 
-#ifdef GLOB_TILDES
+#ifdef GLOB_TILDE
 	/* E.g. musl libc < 1.1.21 does not have this GNU LIBC extension  */
 	flags |= GLOB_TILDE;
 #else

--- a/src/xplugd.c
+++ b/src/xplugd.c
@@ -79,7 +79,7 @@ static int loglvl(char *level)
 	return atoi(level);
 }
 
-static int error_handler(Display *display __attribute__ ((unused)))
+static int error_handler(Display *display)
 {
 	exit(1);
 }

--- a/src/xplugd.c
+++ b/src/xplugd.c
@@ -46,13 +46,17 @@ static char *rcfile(char *arg)
 	/* Simple homegrown replacement that at least handles leading ~/ */
 	if (!strncmp(arg, "~/", 2)) {
 		char *home = NULL;
-		char *arg_tmp = strdup(arg);
+		char *tmp = strdup(arg);
 
 		home = getenv("HOME");
-		if (home) {
-			memmove(arg_tmp + strlen(home)-1, arg_tmp, strlen(arg_tmp));
-			memcpy(arg_tmp, home, strlen(home));
-			arg = arg_tmp;
+		if (home && tmp) {
+			memmove(tmp + strlen(home) - 1, tmp, strlen(tmp));
+			memcpy(tmp, home, strlen(home));
+			arg = tmp;
+		} else {
+			if (tmp) {
+				free(tmp);
+			}
 		}
 	}
 #endif

--- a/src/xplugd.c
+++ b/src/xplugd.c
@@ -77,7 +77,7 @@ static int loglvl(char *level)
 	return atoi(level);
 }
 
-static int error_handler(void)
+static int error_handler(Display *display __attribute__ ((unused)))
 {
 	exit(1);
 }

--- a/src/xplugd.h
+++ b/src/xplugd.h
@@ -44,7 +44,7 @@
 #define MSG_LEN 128
 #define XPLUGRC "~/.xplugrc"
 
-extern int   loglevel;
+extern int loglevel;
 extern char *cmd;
 extern char *prognm;
 


### PR DESCRIPTION
This PR adds a little bit more info printed to stdout when running xplugd's probe mode (see the not very exciting example dump below).

Also, fixed a GCC 8.2 warning.

```
LVDS-1
        Model        : N/A
        Serial Nr.   : N/A
        Width        : 310
        Height       : 170
        Aspect Ratio : N/A
        Gamma        : 2.2
        Prod. Year   : 2010
        Prod. Week   : N/A
        Model Year   : N/A
        Extra        : B140XW03 V1 
        DPMS
                Standby      : N/A
                Suspend      : N/A
                Active Off   : N/A
        Interface    : Undefined
        Display Type (digital)
                RGB 4:4:4    : Yes
                YCrCb 4:4:4  : Yes
                YCrCb 4:2:2  : N/A
        EDID Version : 1.3

```